### PR TITLE
fix: Only specific bots should bypass the CLA workflow

### DIFF
--- a/.github/workflows/f5_cla.yml
+++ b/.github/workflows/f5_cla.yml
@@ -33,7 +33,7 @@ jobs:
           path-to-signatures: signatures/signatures.json
           # Comma separated list of usernames for maintainers or any other individuals who should not be prompted for a CLA.
           # NOTE: You will want to edit the usernames to suit your project needs.
-          allowlist: bot*
+          allowlist: dependabot[bot],renovate[bot],nginx-bot
           # Do not lock PRs after a merge.
           lock-pullrequest-aftermerge: false
         env:


### PR DESCRIPTION
### Proposed changes

The current `allowlist` regex is too permissive. This PR changes the `allowlist` from a regex to specific bots.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`README.md`](/README.md) and [`CHANGELOG.md`](/CHANGELOG.md)).
