### PR TITLE
fix: CLA fails on private repos

### DIFF
--- a/.github/workflows/f5_cla.yml
+++ b/.github/workflows/f5_cla.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       actions: write
+      contents: read
       pull-requests: write
       statuses: write
     steps:


### PR DESCRIPTION
### Proposed changes

This fix ensures the CLA workflow works on private repos.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`README.md`](/README.md) and [`CHANGELOG.md`](/CHANGELOG.md)).
